### PR TITLE
drop the required active_job version

### DIFF
--- a/job-iteration.gemspec
+++ b/job-iteration.gemspec
@@ -26,5 +26,5 @@ Gem::Specification.new do |spec|
   spec.metadata["allowed_push_host"] = "https://rubygems.org"
 
   spec.add_development_dependency("activerecord")
-  spec.add_dependency("activejob", ">= 5.2")
+  spec.add_dependency("activejob", ">= 5.0", "< 5.1")
 end

--- a/lib/job-iteration/iteration.rb
+++ b/lib/job-iteration/iteration.rb
@@ -12,6 +12,7 @@ module JobIteration
         :start_time,
         :times_interrupted,
         :total_time,
+        :executions
       )
 
       define_callbacks :start
@@ -47,6 +48,7 @@ module JobIteration
       super
       self.times_interrupted = 0
       self.total_time = 0.0
+      self.executions = 0
       assert_implements_methods!
     end
     ruby2_keywords(:initialize) if respond_to?(:ruby2_keywords, true)
@@ -56,6 +58,7 @@ module JobIteration
         'cursor_position' => cursor_position,
         'times_interrupted' => times_interrupted,
         'total_time' => total_time,
+        'executions' => executions
       )
     end
 
@@ -64,6 +67,12 @@ module JobIteration
       self.cursor_position = job_data['cursor_position']
       self.times_interrupted = job_data['times_interrupted'] || 0
       self.total_time = job_data['total_time'] || 0
+      self.executions = job_data['executions']
+    end
+
+    def perform_now
+      self.executions = (executions || 0) + 1
+      super
     end
 
     def perform(*params) # @private

--- a/test/unit/active_job_iteration_test.rb
+++ b/test/unit/active_job_iteration_test.rb
@@ -205,7 +205,16 @@ module JobIteration
     end
 
     class FailingIterationJob < SimpleIterationJob
-      retry_on RuntimeError, attempts: 3, wait: 0
+      # retry_on RuntimeError, attempts: 3, wait: 0
+      # this rescue adds a simplified version of `retry_on` which gets
+      # added to ActiveJob in version 5.1
+      rescue_from RuntimeError do
+        if self.executions < 3
+          retry_job
+        else
+          raise
+        end
+      end
 
       def build_enumerator(cursor:)
         enumerator_builder.active_record_on_records(


### PR DESCRIPTION
Changes:
* patches `executions` into the iteration concern as per how Rails does it in newer versions of active job. Bonus that we have some test coverage of the value of `executions` in this gem
* updates a test class with a minimal version of `retry_on` so we can run the tests